### PR TITLE
Replace remark42 comments with giscus

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,6 @@ default: &default
     description: I keep my field green by writing about tech and sometimes life.
     host: http://localhost:8000
     root: ''
-    comments-site: localhost
     author-name: Logan McGrath
     author-email: logan.mcgrath@thisfieldwas.green
     linkedin-profile: https://www.linkedin.com/in/loganmcgrath
@@ -36,7 +35,6 @@ prod:
   site-info:
     <<: *default-site-info
     host: https://thisfieldwas.green
-    comments-site: thisfieldwas.green
 
 review:
   <<: *default
@@ -46,7 +44,6 @@ review:
   site-info:
     <<: *default-site-info
     host: https://review.thisfieldwas.green
-    comments-site: review.thisfieldwas.green
 
 preview:
   <<: *default
@@ -56,4 +53,3 @@ preview:
   site-info:
     <<: *default-site-info
     host: https://preview.thisfieldwas.green
-    comments-site: preview.thisfieldwas.green

--- a/site/_partials/page-comments.html
+++ b/site/_partials/page-comments.html
@@ -1,14 +1,20 @@
 {{#if comments-}}
 <div class="page-comments">
   <p><strong>Please share with me your thoughts and feedback!</strong></p>
-  <script>
-    var remark_config = {
-      host: 'https://remark42.thisfieldwas.green',
-      site_id: '{{siteCommentsId}}',
-      url: '{{absUrl}}'
-    }
+  <script src="https://giscus.app/client.js"
+          data-repo="keywordsalad/thisfieldwas.green"
+          data-repo-id="R_kgDOMROB0Q"
+          data-category="Announcements"
+          data-category-id="DIC_kwDOMROB0c4DBOBD"
+          data-mapping="pathname"
+          data-strict="0"
+          data-reactions-enabled="1"
+          data-emit-metadata="0"
+          data-input-position="bottom"
+          data-theme="light"
+          data-lang="en"
+          crossorigin="anonymous"
+          async>
   </script>
-  <script>!function(e,n){for(var o=0;o<e.length;o++){var r=n.createElement("script"),c=".js",d=n.head||n.body;"noModule"in r?(r.type="module",c=".mjs"):r.async=!0,r.defer=!0,r.src=remark_config.host+"/web/"+e[o]+c,d.appendChild(r)} }(remark_config.components||["embed"],document);</script>
-  <div id="remark42"></div>
 </div>
 {{-#end}}

--- a/src/Green/Config.hs
+++ b/src/Green/Config.hs
@@ -46,7 +46,6 @@ data SiteInfo = SiteInfo
     _siteRoot :: String,
     _siteTitle :: String,
     _siteDescription :: String,
-    _siteCommentsId :: String,
     _siteAuthorName :: String,
     _siteAuthorEmail :: String,
     _siteLinkedInProfile :: String,
@@ -64,7 +63,6 @@ instance FromJSON SiteInfo where
       <*> info .: "root"
       <*> info .: "title"
       <*> info .:? "description" .!= ""
-      <*> info .: "comments-site"
       <*> info .: "author-name"
       <*> info .: "author-email"
       <*> info .: "linkedin-profile"
@@ -78,7 +76,6 @@ instance ToJSON SiteInfo where
         "root" .= _siteRoot,
         "title" .= _siteTitle,
         "description" .= _siteDescription,
-        "comments-site" .= _siteCommentsId,
         "author-name" .= _siteAuthorName,
         "author-email" .= _siteAuthorEmail,
         "linkedin-profile" .= _siteLinkedInProfile,

--- a/src/Green/Template/Context.hs
+++ b/src/Green/Template/Context.hs
@@ -35,7 +35,6 @@ customContext config = self
           constField "siteTitle" (info ^. siteTitle),
           constField "siteDescription" (info ^. siteDescription),
           constField "siteRoot" (info ^. siteRoot),
-          constField "siteCommentsId" (info ^. siteCommentsId),
           constField "authorEmail" (info ^. siteAuthorEmail),
           constField "authorName" (info ^. siteAuthorName),
           constField "author" (info ^. siteAuthorName), -- default to authorName
@@ -43,7 +42,6 @@ customContext config = self
           constField "githubProfile" (info ^. siteGitHubProfile),
           constField "useSocial" True,
           constField "article" False,
-          constField "commentsSiteId" (info ^. siteCommentsId),
           dateFields dateConfig,
           gitFields (config ^. siteProviderDirectory) (info ^. siteGitHubWebUrl),
           defaultFields (info ^. siteHost) (info ^. siteRoot)

--- a/test/Green/TestSupport/Config.hs
+++ b/test/Green/TestSupport/Config.hs
@@ -41,8 +41,7 @@ defaultSiteConfigWith hakyllConfig =
             _siteAuthorEmail = "blogger@thisold.blog",
             _siteLinkedInProfile = "https://linkedin.com/in/xyz1abc2def3ghi4jkl5mno6pqr7stu8vw",
             _siteGitHubProfile = "https://github.com/thisold.blog",
-            _siteGitHubWebUrl = "https://github.com/thisold.blog/blog",
-            _siteCommentsId = "blog"
+            _siteGitHubWebUrl = "https://github.com/thisold.blog/blog"
           },
       _siteCurrentTime = fromJust defaultTestTime,
       _siteTimeLocale = defaultTimeLocale,


### PR DESCRIPTION
## Summary
The old self-hosted **remark42** instance (`remark42.thisfieldwas.green`) is no longer running, so comments were dead. This swaps the comment system to **giscus**, backed by GitHub Discussions on this repo.

- `site/_partials/page-comments.html` — remark42 embed → giscus embed (repo `keywordsalad/thisfieldwas.green`, **Announcements** category, `data-mapping="pathname"`, `data-theme="light"`)
- Dropped the now-dead per-environment comments plumbing, since giscus's repo/category IDs are constant across envs and public by nature:
  - `config.yaml` — removed `comments-site` from all 4 environments
  - `src/Green/Config.hs` — removed the `_siteCommentsId` field (record + FromJSON + ToJSON)
  - `src/Green/Template/Context.hs` — removed `siteCommentsId`/`commentsSiteId` template fields
  - `test/Green/TestSupport/Config.hs` — dropped the corresponding fixture field

The `{{#if comments}}` frontmatter gate is unchanged, so only posts with `comments: true` render the widget.

## Repo setup done
- ✅ GitHub Discussions enabled on the repo
- ✅ Repo confirmed public (required by giscus)

## ⚠️ Manual step required before comments work
Install the **giscus GitHub App** and scope it to this repo: <https://github.com/apps/giscus>. Until installed, the widget shows *"giscus is not installed on this repository."*

## Verification
- `stack build` ✅
- `stack test` — 61/61 passing ✅
- `stack exec site build` ✅ — giscus renders on commented posts, absent on non-commented pages
- No remark42 references remain in source ✅

## Notes
- Theme is pinned to `light` to match the site (no dark mode); trivially swappable to `preferred_color_scheme` later.
- Old remark42 comment history is not migrated (it lived on the retired server); a separate effort if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)