### PR TITLE
giscus: Q&A category + top input, plus repo housekeeping

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
     "hpack",
     "Hspec",
     "inkscape",
+    "keywordsalad",
     "microlens",
     "optparse",
     "prefs",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "cSpell.words": [
+    "acks",
     "bytestring",
     "changefreq",
     "datestamp",
@@ -17,6 +18,7 @@
     "Hspec",
     "inkscape",
     "keywordsalad",
+    "mconcat",
     "microlens",
     "optparse",
     "prefs",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,12 @@
 {
   "cSpell.words": [
     "acks",
+    "Bifunctor",
     "bytestring",
+    "chainl",
     "changefreq",
     "datestamp",
+    "dquote",
     "DYLD",
     "Emph",
     "fmap",
@@ -12,17 +15,29 @@
     "frontmatter",
     "ghcwa",
     "gitea",
+    "gsub",
     "Hakyllbars",
     "hjsmin",
     "hpack",
     "Hspec",
     "inkscape",
     "keywordsalad",
+    "mappend",
     "mconcat",
+    "mempty",
     "microlens",
+    "Monoid",
+    "monoidally",
+    "noindex",
     "optparse",
     "prefs",
     "rewatch",
-    "thisfieldwas"
+    "Semigroup",
+    "squote",
+    "subparser",
+    "succ",
+    "thisfieldwas",
+    "unlines",
+    "unwords"
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/site/_partials/page-comments.html
+++ b/site/_partials/page-comments.html
@@ -1,20 +1,21 @@
 {{#if comments-}}
 <div class="page-comments">
   <p><strong>Please share with me your thoughts and feedback!</strong></p>
-  <script src="https://giscus.app/client.js"
-          data-repo="keywordsalad/thisfieldwas.green"
-          data-repo-id="R_kgDOMROB0Q"
-          data-category="Announcements"
-          data-category-id="DIC_kwDOMROB0c4DBOBD"
-          data-mapping="pathname"
-          data-strict="0"
-          data-reactions-enabled="1"
-          data-emit-metadata="0"
-          data-input-position="bottom"
-          data-theme="light"
-          data-lang="en"
-          crossorigin="anonymous"
-          async>
-  </script>
+  <script
+    src="https://giscus.app/client.js"
+    data-repo="keywordsalad/thisfieldwas.green"
+    data-repo-id="R_kgDOMROB0Q"
+    data-category="Q&A"
+    data-category-id="DIC_kwDOMROB0c4DBOBF"
+    data-mapping="pathname"
+    data-strict="0"
+    data-reactions-enabled="1"
+    data-emit-metadata="0"
+    data-input-position="top"
+    data-theme="light"
+    data-lang="en"
+    crossorigin="anonymous"
+    async
+  ></script>
 </div>
 {{-#end}}


### PR DESCRIPTION
Follow-up to #2 (which merged with the initial giscus setup).

### giscus config (`site/_partials/page-comments.html`)
- **Category:** `Announcements` → `Q&A` (`data-category-id` → matching `DIC_kwDOMROB0c4DBOBF`; name/id pairing verified against the repo's discussion categories)
- **Input position:** `bottom` → `top`

### Repo housekeeping
- `.vscode/settings.json`: add `keywordsalad` to the cSpell dictionary (now appears in `config.yaml` and the giscus partial)
- `CLAUDE.md` → symlink to `AGENTS.md`, so agents keying off `CLAUDE.md` read the same guidance

No generator/Haskell changes. Comments still gated by `{{#if comments}}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)